### PR TITLE
Fix for bungee 1.7

### DIFF
--- a/RedditBot/plugins/minecraft.py
+++ b/RedditBot/plugins/minecraft.py
@@ -38,6 +38,8 @@ def get_info(host, port):
         s.send('\xfe')
         #Send a payload of 0x01 to trigger a new response if the server supports it
         s.send('\x01')
+        #Send an additional byte (bungee requires 3)
+        s.send('\xfa')
 
         #Read as much data as we can (max packet size: 241 bytes)
         d = s.recv(256)


### PR DESCRIPTION
Nerd has supposedly moved to BungeeCord as of 1.7.2. This patch 'fixes' Bungee's broken implementation of the legacy minecraft protocol specification. Still works on versions <1.7.2. 
