### PR TITLE
Fancy regex for version matching

### DIFF
--- a/RedditBot/plugins/minecraft.py
+++ b/RedditBot/plugins/minecraft.py
@@ -76,7 +76,7 @@ def get_info(host='localhost', port=25565):
         # Load json and return
         info = json.loads(d.decode('utf8'))
         return {'protocol_version': info['version']['protocol'],
-                'minecraft_version':    info['version']['name'],
+                'minecraft_version':    re.match('.*([0-9]\.[0-9]\.[0-9]).*',info['version']['name']).groups()[0],
                 'motd':                 info['description'],
                 'players':          info['players']['online'],
                 'max_players':      info['players']['max']}


### PR DESCRIPTION
Bukkit and Spigot both give funny versions (in this case, git-Spigot-1.7.2-R0.1-81-gae87ca8 (MC: 1.7.2)), whereas vanilla just sends the version number. (1.7.2). Pull _a_ version number out of the string. Not guaranteed to be correct, but works for now on all 3. 
