### PR TITLE
Add timeout to server check

### DIFF
--- a/RedditBot/plugins/minecraft.py
+++ b/RedditBot/plugins/minecraft.py
@@ -56,6 +56,7 @@ def get_info(host='localhost', port=25565):
         # Connect
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect((host, port))
+        s.settimeout(2)
 
         # Send handshake + status request
         s.send(pack_data("\x00\x00" + pack_data(host.encode('utf8')) + pack_port(port) + "\x01"))


### PR DESCRIPTION
Not sure why this doesn't exist - if servers are offline .status and .isup both take forever to timeout. If a server can't respond in 2000ms, its practically offline anyways. 
