### PR TITLE
Update version number, spigot broke it again

### DIFF
--- a/RedditBot/plugins/minecraft.py
+++ b/RedditBot/plugins/minecraft.py
@@ -77,7 +77,7 @@ def get_info(host='localhost', port=25565):
         # Load json and return
         info = json.loads(d.decode('utf8'))
         return {'protocol_version': info['version']['protocol'],
-                'minecraft_version':    re.match('.*([0-9]\.[0-9]\.[0-9]).*',info['version']['name']).groups()[0],
+                'minecraft_version':    re.match('.*((\d\.)+\d).*',info['version']['name']).groups()[0],
                 'motd':                 info['description'],
                 'players':          info['players']['online'],
                 'max_players':      info['players']['max']}


### PR DESCRIPTION
Title says it all. get_info() now uses ((\d.)+\d) for its regex, should pick up any future version problems (minus "Minecraft 2")
